### PR TITLE
Disregard empty sproxyd endpoint

### DIFF
--- a/scality_sproxyd_client/sproxyd_client.py
+++ b/scality_sproxyd_client/sproxyd_client.py
@@ -74,7 +74,7 @@ class SproxydClient(object):
         self._endpoints = frozenset(
             endpoint if not isinstance(endpoint, basestring)
             else urlparse.urlparse(endpoint)
-            for endpoint in endpoints)
+            for endpoint in endpoints if endpoint)
 
         if not self._endpoints:
             raise ValueError("At least one Sproxyd endpoint "

--- a/test/unit/test_sproxyd_client.py
+++ b/test/unit/test_sproxyd_client.py
@@ -43,6 +43,15 @@ class TestSproxydClient(unittest.TestCase):
     def test_init_with_invalid_endpoint(self):
         self.assertRaises(ValueError, SproxydClient, ['invalid://'])
 
+    def test_init_with_empty_endpoint(self):
+        self.assertRaises(ValueError, SproxydClient, [''])
+
+    def test_init_with_some_empty_endpoints(self):
+        sproxyd_client = SproxydClient(['', 'http://host:81/path/', ''])
+        self.assertEqual(
+            frozenset([urlparse.urlparse('http://host:81/path/')]),
+            sproxyd_client._endpoints)
+
     def test_init_with_endpoint_with_params(self):
         utils.assertRaisesRegexp(ValueError, '.* params .*',
                                  SproxydClient, ['http://host:81/path;param'])


### PR DESCRIPTION
The `SproxydClient` constructor accepts an iterable of strings as
the `endpoints` parameter. Problem is when that `endpoints` parameter
comes from the parsing of an `oslo_config.ListOpt` and the user
adds some trailing comma then `endpoints` could be `['http://blag', '']`.

In that case the contructor raises a weird  "ValueError: Unknown endpoint
scheme: '' in ''". We shouldn't fail on something as simple as a trailing
comma. Instead just ignore it.